### PR TITLE
Added checks to prevent tainting

### DIFF
--- a/Locales/enUS.lua
+++ b/Locales/enUS.lua
@@ -90,5 +90,4 @@ L["With animation"] = true
 L["You can now move the frames by dragging them around."] = true
 L["You may drag the frame around when this option is set."] = true
 L["You need to re-open this window when changing breed settings."] = true
-
-
+L["ToDebugString"] = true

--- a/Modules/WildPetTooltip.lua
+++ b/Modules/WildPetTooltip.lua
@@ -88,8 +88,9 @@ function module:ProcessTooltipClassic(tooltip)
 end
 
 function module:ProcessTooltip(tooltip)
-	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(tooltip) then return end end
 	local name, unit = tooltip:GetUnit();
+	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(name) then return end end
+	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(unit) then return end end
 
 	local func = self.db.profile.onlywildpets and _G.UnitIsWildBattlePet or _G.UnitIsBattlePet;
 	if (not unit or not func(unit)) then

--- a/Modules/WildPetTooltip.lua
+++ b/Modules/WildPetTooltip.lua
@@ -88,6 +88,7 @@ function module:ProcessTooltipClassic(tooltip)
 end
 
 function module:ProcessTooltip(tooltip)
+	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(tooltip) then return end end
 	local name, unit = tooltip:GetUnit();
 
 	local func = self.db.profile.onlywildpets and _G.UnitIsWildBattlePet or _G.UnitIsBattlePet;

--- a/Modules/WildPetTooltip.lua
+++ b/Modules/WildPetTooltip.lua
@@ -89,8 +89,7 @@ end
 
 function module:ProcessTooltip(tooltip)
 	local name, unit = tooltip:GetUnit();
-	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(name) then return end end
-	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(unit) then return end end
+	if WOW_PROJECT_ID == WOW_PROJECT_MAINLINE then if issecretvalue(name) or issecretvalue(unit) then return end end
 
 	local func = self.db.profile.onlywildpets and _G.UnitIsWildBattlePet or _G.UnitIsBattlePet;
 	if (not unit or not func(unit)) then


### PR DESCRIPTION
- [x] added "todebugstring" to local enus and stopped one an issue with that not being stated (cannot find how it's being called. suspect it's in ace itself somehow)
- [x] added several checks with minor testing. these check for mainline, and then if true check for secret values and skip out before doing anything. this prevents unintentional tainting when blizzard calls this at random
- [x] addresses blizzard's odd calling in reported in https://github.com/GurliGebis/WoWAddon-PokemonTrainerNG/issues/26
- [x] probably addresses blizzard's issue in reported in https://github.com/GurliGebis/WoWAddon-PokemonTrainerNG/issues/28
- [x] tested without more issues or lua taint errors since may 23 2026

note: i dont want credit, i just want the mod fixed.