### PR TITLE
prevent loading corruption during combat

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,6 @@
+# 12.1.0-20260819-1
+* Prevent loading corruption during combat.
+
 # 12.1.0-20260813-1
 * Updated Loader TOC to match 12.1.0 as well
 

--- a/Loader/Loader.Lua
+++ b/Loader/Loader.Lua
@@ -28,6 +28,7 @@ f:SetScript("OnEvent", function(self, event, ...)
             f:UnregisterEvent(event);
         end
     elseif( event == "UPDATE_MOUSEOVER_UNIT" ) then
+        if InCombatLockdown() then return end -- skip in combat
         local ok, name, unit = pcall(_G.GameTooltip.GetUnit, _G.GameTooltip);
         -- If GetUnit failed (e.g. due to secret values in instances), bail out.
         if not ok then return end


### PR DESCRIPTION
this addresses https://github.com/GurliGebis/WoWAddon-PokemonTrainerNG/issues/29
it is only meant to address that one issue and does not add any other corruption checks for prevention